### PR TITLE
Hotfix/loader

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,12 @@
       - "--strip-components=1"
     creates: /tools/SourcePoint/SourcePoint.go
 
+- name: Edit Loader.go to remove line
+  ansible.builtin.lineinfile:
+    path: /tools/SourcePoint/Loader/Loader.go
+    state: absent
+    search_string: 'PE_Name[1]'
+
 - name: Build SourcePoint
   ansible.builtin.shell: source /etc/profile.d/go-path.sh && go get gopkg.in/yaml.v2 && go build SourcePoint.go
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,10 +16,10 @@
     creates: /tools/SourcePoint/SourcePoint.go
 
 - name: Edit Loader.go to remove line
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: /tools/SourcePoint/Loader/Loader.go
-    state: absent
-    search_string: 'PE_Name[1]'
+    regexp: 'PE\[5]'
+    replace: 'PE[len(PE)-3]'
 
 - name: Build SourcePoint
   ansible.builtin.shell: source /etc/profile.d/go-path.sh && go get gopkg.in/yaml.v2 && go build SourcePoint.go


### PR DESCRIPTION
# Fix for line in Loader.go #

## 🗣 Description ##

Changed indexing of PE variable in Loader.go to reference length-2 rather than 5 because of varying array lengths

## 💭 Motivation and context ##

With the hard-coded number, the script fails when the length is not 7

## 🧪 Testing ##

Test by running the playbook and ensuring that the Loader.go has 'PE[len(PE)-3]' on line 93 and that the SourcePoint script does not fail

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
